### PR TITLE
List item class

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ isCollapsedClass: 'is-collapsed',
 // Class that gets added when a list should be able
 // to be collapsed but isn't necessarily collpased.
 collapsibleClass: 'is-collapsible',
+// Class to add to list items.
+listItemClass: 'toc-list-item',
 // How many heading levels should not be collpased.
 // For example, number 6 will show everything since
 // there are only 6 heading levels and number 0 will collpase them all.

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -67,6 +67,7 @@ module.exports = function(options) {
   function createLink(data) {
     var item = document.createElement('li');
     var a = document.createElement('a');
+    item.setAttribute('class', options.listItemClass);
     a.textContent = data.textContent;
     // Property for smooth-scroll.
     a.setAttribute('data-scroll', '');

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -30,6 +30,8 @@ module.exports = {
   // Class that gets added when a list should be able
   // to be collapsed but isn't necessarily collpased.
   collapsibleClass: 'is-collapsible',
+  // Class to add to list items.
+  listItemClass: 'toc-list-item',
   // How many heading levels should not be collpased.
   // For example, number 6 will show everything since
   // there are only 6 heading levels and number 0 will collpase them all.


### PR DESCRIPTION
Allow list item class to be specified using the `listItemClass` configuration option, which defaults to `'toc-list-item'`.

See issue #12.