### PR TITLE
Heading html

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ positionFixedClass: 'is-position-fixed',
 // fixedSidebarOffset can be any number but by default is set
 // to auto which sets the fixedSidebarOffset to the sidebar
 // element's offsetTop from the top of the document on init.
-fixedSidebarOffset: 'auto'
+fixedSidebarOffset: 'auto',
+// includeHtml can be set to true to include the HTML markup from the
+// heading node instead of just including the textContent.
+includeHtml: false
 ```
 
 
@@ -180,10 +183,19 @@ tocbot.refresh()
 ## Changelog
 
 
+### v2.1.4
+
+#### Added
+- [patch] `includeHtml` option to mirror markup from the headings in the TOC (#14).
+- [patch] `listItemClass` will be omitted if an empty string in passed.
+- [dev] `test:watch` command.
+- [dev] more tests.
+
+
 ### v2.1.3
 
 #### Added
-- [patch] `listItemClass` option to set classes on list items (#12)
+- [patch] `listItemClass` option to set classes on list items (#12).
 
 
 ### v2.1.2
@@ -195,44 +207,44 @@ tocbot.refresh()
 ### v2.1.1
 
 #### Changed
-- [patch] update file size estimates in the docs
-- [patch] switch from throwing errors to using console.warn
+- [patch] update file size estimates in the docs.
+- [patch] switch from throwing errors to using console.warn.
 
 
 ### v2.1
 
 #### Added
-- [minor] add `positionFixedSelector` option to specify the element to add a fixed position class to
-- [dev] use travis-ci for builds
+- [minor] add `positionFixedSelector` option to specify the element to add a fixed position class to.
+- [dev] use travis-ci for builds.
 
 
 ### v2.0
 
 #### Added
-- [major] smooth-scroll is included by default now
-- [patch] throttling support to improve performance, also the `throttleTimeout` option
-- [patch] new "try it now" option on documentation site
+- [major] smooth-scroll is included by default now.
+- [patch] throttling support to improve performance, also the `throttleTimeout` option.
+- [patch] new "try it now" option on documentation site.
 
 #### Changed
-- [minor] broke up scss files and separate tocbot styles better
-- [minor] default option for `contentSelector` to be `.js-toc-content`
-- [minor] default option for `ignoreSelector` to be `.js-toc-ignore`
-- [minor] default option for `collapsibleClass` to be `.is-collapsible`
-- [patch] reorder `default-options.js`
-- [patch] update documentation
+- [minor] broke up scss files and separate tocbot styles better.
+- [minor] default option for `contentSelector` to be `.js-toc-content`.
+- [minor] default option for `ignoreSelector` to be `.js-toc-ignore`.
+- [minor] default option for `collapsibleClass` to be `.is-collapsible`.
+- [patch] reorder `default-options.js`.
+- [patch] update documentation.
 
 #### Removed
-- [patch] dependency on classList to improve browser support
+- [patch] dependency on classList to improve browser support.
 
 #### Fixed
-- [minor] new and improved tests using jsdom
-- [dev] switched from gulp to npm scripts
-- [dev] switched from browserify to webpack
-- [dev] switched from swig to react for building the documentation
+- [minor] new and improved tests using jsdom.
+- [dev] switched from gulp to npm scripts.
+- [dev] switched from browserify to webpack.
+- [dev] switched from swig to react for building the documentation.
 
 
 ### v1.0
-- First published source code
+- First published source code.
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tocbot",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Generate a table of contents based on the heading structure of a html document.",
   "main": "src/js/index.js",
   "scripts": {
@@ -24,7 +24,8 @@
     "serve": "webpack-dev-server --content-base build/ --port 4001",
     "start": "npm run clean && npm run mkdirs && npm run build-css && npm run build-docs && npm run dev",
     "deploy": "npm run build && gh-pages -d build",
-    "test": "mocha test/index.js"
+    "test": "mocha test/index.js",
+    "test:watch": "mocha --watch test/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -67,11 +67,17 @@ module.exports = function(options) {
   function createLink(data) {
     var item = document.createElement('li');
     var a = document.createElement('a');
-    item.setAttribute('class', options.listItemClass);
-    // a.textContent = data.textContent;
-    forEach.call(data.childNodes, function(node) {
-      a.appendChild(node.cloneNode(true));
-    });
+    if (options.listItemClass) {
+      item.setAttribute('class', options.listItemClass);
+    }
+    if (options.includeHtml && data.childNodes.length) {
+      forEach.call(data.childNodes, function(node) {
+        a.appendChild(node.cloneNode(true));
+      });
+    } else {
+      // Default behavior.
+      a.textContent = data.textContent;
+    }
     // Property for smooth-scroll.
     a.setAttribute('data-scroll', '');
     a.setAttribute('href', '#' + data.id);

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -68,7 +68,10 @@ module.exports = function(options) {
     var item = document.createElement('li');
     var a = document.createElement('a');
     item.setAttribute('class', options.listItemClass);
-    a.textContent = data.textContent;
+    // a.textContent = data.textContent;
+    forEach.call(data.childNodes, function(node) {
+      a.appendChild(node.cloneNode(true));
+    });
     // Property for smooth-scroll.
     a.setAttribute('data-scroll', '');
     a.setAttribute('href', '#' + data.id);

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -59,5 +59,8 @@ module.exports = {
   // fixedSidebarOffset can be any number but by default is set
   // to auto which sets the fixedSidebarOffset to the sidebar
   // element's offsetTop from the top of the document on init.
-  fixedSidebarOffset: 'auto'
+  fixedSidebarOffset: 'auto',
+  // includeHtml can be set to true to include the HTML markup from the
+  // heading node instead of just including the textContent.
+  includeHtml: false
 };

--- a/src/js/parse-content.js
+++ b/src/js/parse-content.js
@@ -32,14 +32,19 @@ module.exports = function parseContent(options) {
    * @return {Object}
    */
   function getHeadingObject(heading) {
-    return {
+    var obj = {
       id: heading.id,
       children: [],
       nodeName: heading.nodeName,
       headingLevel: getHeadingLevel(heading),
-      textContent: heading.textContent.trim(),
-      childNodes: heading.childNodes
+      textContent: heading.textContent.trim()
     };
+
+    if (options.includeHtml) {
+      obj.childNodes = heading.childNodes;
+    }
+
+    return obj;
   }
 
   /**

--- a/src/js/parse-content.js
+++ b/src/js/parse-content.js
@@ -37,7 +37,8 @@ module.exports = function parseContent(options) {
       children: [],
       nodeName: heading.nodeName,
       headingLevel: getHeadingLevel(heading),
-      textContent: heading.textContent.trim()
+      textContent: heading.textContent.trim(),
+      childNodes: heading.childNodes
     };
   }
 


### PR DESCRIPTION
### v2.1.4

#### Added
- [patch] `includeHtml` option to mirror markup from the headings in the TOC (#14).
- [patch] `listItemClass` will be omitted if an empty string in passed.
- [dev] `test:watch` command.
- [dev] more tests.