### PR TITLE
Various minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,34 @@ If you want to open a pull request just fork the repo but please make sure all t
 
 ### Running Tests
 
+#### All tests
 ```bash
-npm test
+npm run test
 ```
 
+#### Specific tests
+To filter tests by `describe` or `it` description:
+```bash
+TEST_NAME="some string that appears in the test description" npm run test
+```
+
+#### With debugger
+You can run tests through [node-inspector](https://github.com/node-inspector/node-inspector).
+
+[For now, you may need to use node v6 or lower](https://github.com/node-inspector/node-inspector/issues/950#issuecomment-264289415)...
+```bash
+nvm use 6
+```
+
+Once you're on node v6 or lower:
+```bash
+npm install node-inspector
+```
+
+Now that node-inspector is installed, you can run the tests!
+```
+TEST_NAME="whatever, this is optional" npm run test:debug
+```
 
 ## Steps to publish
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ tocbot.refresh();
 
 - [Tocbot Homepage](http://tscanlin.github.io/tocbot/)
 - [Optimizely's Developer Documentation](https://developers.optimizely.com/x/solutions/javascript/reference/index.html)
+
 If you'd like to add your page to this list open a pull request.
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "serve": "webpack-dev-server --content-base build/ --port 4001",
     "start": "npm run clean && npm run mkdirs && npm run build-css && npm run build-docs && npm run dev",
     "deploy": "npm run build && gh-pages -d build",
-    "test": "mocha test/index.js",
+    "test": "mocha --grep \"$TEST_NAME\" test/index.js",
+    "test:debug": "node-debug _mocha --timeout 0 --grep \"$TEST_NAME\" test/index.js",
     "test:watch": "mocha --watch test/index.js"
   },
   "repository": {


### PR DESCRIPTION
I would have added node-inspector the devDependencies in order to enable the test:debug script, but that would currently break `npm install` for folks on node v7 because of node-inspector/node-inspector#950.

For now, I've documented that `npm install node-inspector` has to be run manually on node v6 or lower.
