### PR TITLE
Make current section highlighted instead of previous

### DIFF
--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -145,7 +145,7 @@ module.exports = function(options) {
       && document.querySelector(options.tocSelector) !== null
       && headings.length > 0) {
       some.call(headings, function(heading, i) {
-        if (heading.offsetTop > top + options.headingsOffset) {
+        if (heading.offsetTop > top + options.headingsOffset + 1) {
           // Don't allow negative index value.
           var index = (i === 0) ? i : i - 1;
           topHeader = headings[index];


### PR DESCRIPTION
When I go directly to a link, it highlights the link before the
one I am visiting. I put some console.log() statements in and it looks
like it's some sub-pixel rounding problem?

I experience the issue on my own site and also the official tocbot
docs page, in both chromium and firefox (on linux). This patch fixes
the issue for my site in both browsers.