### PR TITLE
Re-add support for unordered lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ includeHtml: false,
 // onclick function to apply to all links in toc. will be called with
 // the event as the first parameter, and this can be used to stop,
 // propagation, prevent default or perform action
-onClick: false
+onClick: false,
+// orderedList can be set to false to generate unordered lists (ul)
+// instead of ordered lists (ol)
+orderedList: true
 ```
 
 

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -101,7 +101,7 @@ module.exports = function (options) {
    * @return {HTMLElement}
    */
   function createList (isCollapsed) {
-    var listElement = (options.orderedList === false) ? 'ul' : 'ol'
+    var listElement = (options.orderedList) ? 'ol' : 'ul'
     var list = document.createElement(listElement)
     var classes = options.listClass +
       SPACE_CHAR + options.extraListClasses

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -101,7 +101,8 @@ module.exports = function (options) {
    * @return {HTMLElement}
    */
   function createList (isCollapsed) {
-    var list = document.createElement('ol')
+    var listElement = (options.orderedList === false) ? 'ul' : 'ol'
+    var list = document.createElement(listElement)
     var classes = options.listClass +
       SPACE_CHAR + options.extraListClasses
     if (isCollapsed) {

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -59,5 +59,8 @@ module.exports = {
   // onclick function to apply to all links in toc. will be called with
   // the event as the first parameter, and this can be used to stop,
   // propagation, prevent default or perform action
-  onClick: false
+  onClick: false,
+  // orderedList can be set to false to generate unordered lists (ul)
+  // instead of ordered lists (ol)
+  orderedList: true
 }


### PR DESCRIPTION
I see that unordered lists were replaced with ordered lists, per https://github.com/tscanlin/tocbot/pull/73/files, but might you be amenable to supporting both, even though `ol` is indeed compelling semantically?

Thank you!