### PR TITLE
suggestion for issue #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ contentSelector: '.js-toc-content',
 headingSelector: 'h1, h2, h3',
 // Headings that match the ignoreSelector will be skipped.
 ignoreSelector: '.js-toc-ignore',
+// For headings inside relative or absolute positioned containers within content
+hasInnerContainers: false,
 // Main class to add to links.
 linkClass: 'toc-link',
 // Extra classes to add to links.

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -139,6 +139,35 @@ module.exports = function (options) {
   }
 
   /**
+   * Get top position of heading
+   * @param {HTMLElement}
+   * @return {integer} position
+   */
+  // function getHeadingTopPos (heading) {
+  //   var position = 0
+  //   if (options.hasInnerContainers) {
+  //     var obj = heading
+  //     do {
+  //       position += obj.offsetTop
+  //       obj = obj.offsetParent
+  //     } while ( obj != null && obj != document.querySelector(options.contentSelector))
+  //   }
+  //   else
+  //     position = heading.offsetTop
+  //   return position
+  // }
+
+  function getHeadingTopPos (obj) {
+    var position = 0
+    if (obj != document.querySelector(options.contentSelector && obj != null)) {
+      position = obj.offsetTop
+      if (options.hasInnerContainers)
+        position += getHeadingTopPos(obj.offsetParent)
+    }
+    return position
+  }
+
+  /**
    * Update TOC highlighting and collpased groupings.
    */
   function updateToc (headingsArray) {
@@ -162,7 +191,7 @@ module.exports = function (options) {
       document.querySelector(options.tocSelector) !== null &&
       headings.length > 0) {
       some.call(headings, function (heading, i) {
-        if (heading.offsetTop > top + options.headingsOffset + 10) {
+        if (getHeadingTopPos(heading) > top + options.headingsOffset + 10) {
           // Don't allow negative index value.
           var index = (i === 0) ? i : i - 1
           topHeader = headings[index]

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -143,20 +143,6 @@ module.exports = function (options) {
    * @param {HTMLElement}
    * @return {integer} position
    */
-  // function getHeadingTopPos (heading) {
-  //   var position = 0
-  //   if (options.hasInnerContainers) {
-  //     var obj = heading
-  //     do {
-  //       position += obj.offsetTop
-  //       obj = obj.offsetParent
-  //     } while ( obj != null && obj != document.querySelector(options.contentSelector))
-  //   }
-  //   else
-  //     position = heading.offsetTop
-  //   return position
-  // }
-
   function getHeadingTopPos (obj) {
     var position = 0
     if (obj != document.querySelector(options.contentSelector && obj != null)) {

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -7,6 +7,8 @@ module.exports = {
   headingSelector: 'h1, h2, h3',
   // Headings that match the ignoreSelector will be skipped.
   ignoreSelector: '.js-toc-ignore',
+  // For headings inside relative or absolute positioned containers within content
+  hasInnerContainers: false,
   // Main class to add to links.
   linkClass: 'toc-link',
   // Extra classes to add to links.

--- a/src/scss/_page-styles.scss
+++ b/src/scss/_page-styles.scss
@@ -15,6 +15,7 @@ body {
 }
 
 .content {
+  position: relative;
   // margin-right: 280px;
   h1:first-child, h2:first-child {
     padding-top: 0;


### PR DESCRIPTION
If `hasInnerContainers` is set to `true`, the `offsetTop` of the heading is recursively added up with the `offsetTop` values of it's parent positioned containers, until the `contentSelector` container is reached. Therefore the `contentSelector` container should have `position: relative`. If not, the document root is reached.