### PR TITLE
introduce new skipRendering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ onClick: false,
 // instead of ordered lists (ol)
 orderedList: true,
 // If there is a fixed article scroll container, set to calculate titles' offset
-scrollContainer: null
+scrollContainer: null,
+// prevent ToC DOM rendering if it's already rendered by an external system
+skipRendering: false
 ```
 
 

--- a/pages/skipRendering.js
+++ b/pages/skipRendering.js
@@ -47,7 +47,7 @@ const Index = (props) => {
       user={CONFIG.user}
       siteId={CONFIG.siteId}
       extraElements={<TryIt />}
-      tocbotOptions={{ render: false }}
+      tocbotOptions={{ skipRendering: true }}
     />
   )
 }

--- a/pages/skipRendering.js
+++ b/pages/skipRendering.js
@@ -4,7 +4,7 @@ import TryIt from '../src/components/Template/TryIt'
 
 import CONFIG from './_config.js'
 
-const lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum"
+const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
 
 const bodyHtml = `
   <H2 id="first">First Title</H2>

--- a/pages/skipRendering.js
+++ b/pages/skipRendering.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import Template from '../src/components/Template'
+import TryIt from '../src/components/Template/TryIt'
+
+import CONFIG from './_config.js'
+
+const lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum"
+
+const bodyHtml = `
+  <H2 id="first">First Title</H2>
+  <p>${lorem}</p>
+  <H2 id="second">Second Title</H2>
+  <p>${lorem}</p>
+  <H3 id="second-a">Subtitle A</H3>
+  <p>${lorem}</p>
+  <H3 id="second-b">Subtitle B</H3>
+  <p>${lorem}</p>
+  <H2 id="third">Third Title</H2>
+  <p>${lorem}</p>
+`
+
+// do not put spaces after </a> or it creates a sibling text elt
+const tocHtml = `
+  <ol class="toc-list">
+    <li class="toc-list-item"><a class="toc-link node-name--H2" href="#first">First title</a></li>
+    <li class="toc-list-item">
+      <a class="toc-link node-name--H2" href="#second">Second title</a>
+      <ol class="toc-list is-collapsible">
+      <li class="toc-list-item"><a class="toc-link node-name--H3" href="#second-a">Subtitle A</a></li>
+      <li class="toc-list-item"><a class="toc-link node-name--H3" href="#second-b">Subtitle B</a></li>
+      </ol>
+    </li>
+    <li class="toc-list-item"><a class="toc-link node-name--H2" href="#third">First title</a></li>
+  </ol>`
+
+const Index = (props) => {
+  return (
+    <Template
+      title={CONFIG.title}
+      subtitle={CONFIG.subtitle}
+      description={CONFIG.description}
+      stylesheets={CONFIG.stylesheets}
+      topLinks={CONFIG.topLinks}
+      bodyHtml={bodyHtml}
+      tocHtml={tocHtml}
+      repo={CONFIG.repo}
+      user={CONFIG.user}
+      siteId={CONFIG.siteId}
+      extraElements={<TryIt />}
+      tocbotOptions={{ render: false }}
+    />
+  )
+}
+
+export default Index

--- a/src/components/Template/Tocbot/index.js
+++ b/src/components/Template/Tocbot/index.js
@@ -17,7 +17,7 @@ const tocbot = (typeof window !== 'undefined')
 export default class Tocbot extends React.Component {
   componentDidMount () {
     if (tocbot) {
-      tocbot.init(TOCBOT_OPTIONS)
+      tocbot.init(Object.assign({}, this.props, TOCBOT_OPTIONS))
     }
   }
 

--- a/src/components/Template/Tocbot/index.js
+++ b/src/components/Template/Tocbot/index.js
@@ -17,7 +17,7 @@ const tocbot = (typeof window !== 'undefined')
 export default class Tocbot extends React.Component {
   componentDidMount () {
     if (tocbot) {
-      tocbot.init(Object.assign({}, this.props, TOCBOT_OPTIONS))
+      tocbot.init(Object.assign({}, TOCBOT_OPTIONS, this.props))
     }
   }
 

--- a/src/components/Template/index.js
+++ b/src/components/Template/index.js
@@ -31,11 +31,13 @@ function Template (props) {
           <label className='toc-icon relative pointer z-2 f6 lh-solid bg-near-white b--silver pa1 ma1 ba br1' htmlFor='toc'>
             Menu
           </label>
-          <nav className='toc toc-right js-toc relative z-1 transition--300 absolute pa4' />
+          <nav
+            className='toc toc-right js-toc relative z-1 transition--300 absolute pa4'
+            dangerouslySetInnerHTML={{ __html: props.tocHtml }} />
           <div className='content js-toc-content pa4'
             dangerouslySetInnerHTML={{ __html: props.bodyHtml }} />
 
-          <Tocbot />
+          <Tocbot {...props.tocbotOptions} />
         </div>
         {props.extraElements}
 

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -70,5 +70,5 @@ module.exports = {
   // If there is a fixed article scroll container, set to calculate titles' offset
   scrollContainer: null,
   // prevent ToC DOM rendering if it's already rendered
-  skipRendering: true
+  skipRendering: false
 }

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -68,5 +68,7 @@ module.exports = {
   // instead of ordered lists (ol)
   orderedList: true,
   // If there is a fixed article scroll container, set to calculate titles' offset
-  scrollContainer: null
+  scrollContainer: null,
+  // prevent ToC DOM rendering if it's already rendered
+  skipRendering: true
 }

--- a/src/js/default-options.js
+++ b/src/js/default-options.js
@@ -69,6 +69,6 @@ module.exports = {
   orderedList: true,
   // If there is a fixed article scroll container, set to calculate titles' offset
   scrollContainer: null,
-  // prevent ToC DOM rendering if it's already rendered
+  // prevent ToC DOM rendering if it's already rendered by an external system
   skipRendering: false
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -138,7 +138,9 @@
     this._parseContent = parseContent
 
     // Destroy it if it exists first.
-    tocbot.destroy()
+    if (options.skipRendering) {
+      tocbot.destroy()
+    }
 
     // Get headings array.
     headingsArray = parseContent.selectHeadings(options.contentSelector, options.headingSelector)
@@ -152,7 +154,9 @@
     var nestedHeadings = nestedHeadingsObj.nest
 
     // Render.
-    buildHtml.render(options.tocSelector, nestedHeadings)
+    if (options.skipRendering) {
+      buildHtml.render(options.tocSelector, nestedHeadings)
+    }
 
     // Update Sidebar and bind listeners.
     this._scrollListener = throttle(function (e) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -83,11 +83,13 @@
    * Destroy tocbot.
    */
   tocbot.destroy = function () {
-    // Clear HTML.
-    try {
-      document.querySelector(options.tocSelector).innerHTML = ''
-    } catch (e) {
-      console.warn('Element not found: ' + options.tocSelector); // eslint-disable-line
+    if (!options.skipRendering) {
+      // Clear HTML.
+      try {
+        document.querySelector(options.tocSelector).innerHTML = ''
+      } catch (e) {
+        console.warn('Element not found: ' + options.tocSelector); // eslint-disable-line
+      }
     }
 
     // Remove event listeners.
@@ -138,9 +140,7 @@
     this._parseContent = parseContent
 
     // Destroy it if it exists first.
-    if (!options.skipRendering) {
-      tocbot.destroy()
-    }
+    tocbot.destroy()
 
     // Get headings array.
     headingsArray = parseContent.selectHeadings(options.contentSelector, options.headingSelector)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -138,7 +138,7 @@
     this._parseContent = parseContent
 
     // Destroy it if it exists first.
-    if (options.skipRendering) {
+    if (!options.skipRendering) {
       tocbot.destroy()
     }
 
@@ -154,7 +154,7 @@
     var nestedHeadings = nestedHeadingsObj.nest
 
     // Render.
-    if (options.skipRendering) {
+    if (!options.skipRendering) {
       buildHtml.render(options.tocSelector, nestedHeadings)
     }
 


### PR DESCRIPTION
Hello and thanks for a great library @tscanlin :) 

I'm about to use it on https://codedutravail-dev.num.social.gouv.fr/kali/1747-convention-collective-nationale-des-activites-industrielles-de-boulangerie , a french public website that helps employees understand work laws. As you can see there's some heavy table of contents. I don't want to completely delegate the generation of the DOM to tocbot, only use the scroll listener feature to autofocus the right one.

<img width="736" alt="Screen Shot 2019-05-21 at 11 42 00" src="https://user-images.githubusercontent.com/883348/58085671-772d3e80-7bbd-11e9-98d7-fc8f9291651b.png">

In this PR I'm therefore introducing a `skipRendering` option that does just that.

Let me know if that's a feature you'd be interested in integrating into the core tocbot, and in which case what you'd like me to improve on this PR! 