### PR TITLE
fix: Typescript definition for onClick event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ declare namespace tocbot {
     // onclick function to apply to all links in toc. will be called with
     // the event as the first parameter; and this can be used to stop;
     // propagation; prevent default or perform action
-    onClick?: (e: ClickEvent) => void;
+    onClick?: (e: MouseEvent) => void;
 
     // orderedList can be set to false to generate unordered lists (ul)
     // instead of ordered lists (ol)


### PR DESCRIPTION
Hi there 👋 

As mentioned in the original issue (#162), the TypeScript DOM lib doesn't have a `ClickEvent` interface, but does have a `MouseEvent` type.
closes #162

Cheers!