### PR TITLE
fix generation of a proper id for headers with a forward slash

### DIFF
--- a/src/utils/make-ids.js
+++ b/src/utils/make-ids.js
@@ -4,7 +4,7 @@ var headingMap = {}
 
 Array.prototype.forEach.call(headings, function (heading) {
   var id = heading.id ? heading.id : heading.textContent.trim().toLowerCase()
-    .split(' ').join('-').replace(/[!@#$%^&*():]/ig, '')
+    .split(' ').join('-').replace(/[!@#$%^&*():]/ig, '').replace(/\//ig, '-')
   headingMap[id] = !isNaN(headingMap[id]) ? ++headingMap[id] : 0
   if (headingMap[id]) {
     heading.id = id + '-' + headingMap[id]


### PR DESCRIPTION
Fix an issue in `make-ids.js` where headers with a forward slash (eg, `some text to include/exclude`) was not properly sanitized (eg, `some-text-to-include/exclude`, which then caused an error with tocbot). With this PR, forward slashes are replaced with a dash (eg, `some-text-to-include-exclude`).