### PR TITLE
Add typescript definition for basePath and disableTocScrollSync

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,13 @@ declare namespace tocbot {
     // Function has to return the same or modified obj. 
     // The heading will be excluded from TOC if nothing is returned.
     headingObjectCallback?: (obj: object, node: HTMLElement) => object | void;
+
+    // Set the base path, useful if you use a `base` tag in `head`.
+    basePath?: string,
+
+    // Only takes affect when `tocSelector` is scrolling,
+    // keep the toc scroll position in sync with the content.
+    disableTocScrollSync?: boolean
   }
 
   /**


### PR DESCRIPTION
When trying to use `disableTocScrollSync` in one of our projects, ts complained about the option missing in the declaration file.

I also added the option `basePath`

Thanks