### PR TITLE
docs: fix link to MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ npm run test
 
 ## License
 
-[MIT]('http://opensource.org/licenses/MIT')
+[MIT](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
Fixed the markdown formatting.