### PR TITLE
Add scrollSmoothOffset to type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,9 @@ declare namespace tocbot {
 
     // Smooth scroll duration.
     scrollSmoothDuration?: number;
+    
+    // Smooth scroll offset.
+    scrollSmoothOffset?: number;
 
     // Callback for scroll end.
     scrollEndCallback?(e: MouseWheelEvent): void;


### PR DESCRIPTION
Unfortunately `scrollSmoothOffset` is missing in the type declarations which causes some TS issues. This should fix it.