### PR TITLE
Fix Deprecated Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace tocbot {
     scrollSmoothOffset?: number;
 
     // Callback for scroll end.
-    scrollEndCallback?(e: MouseWheelEvent): void;
+    scrollEndCallback?(e: WheelEvent): void;
 
     // Headings offset between the headings and the top of the document (this is meant for minor adjustments).
     headingsOffset?: number;


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/MouseWheelEvent the MouseWheelEvent is deprecated and should be replaced by WheelEvent (https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent) - this change is important since in version 4.4.0 and onwards of Typescript this breaks the build process for repos depending on the library. See https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1029#issuecomment-907141728