### PR TITLE
Fix refresh type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,5 +148,5 @@ declare namespace tocbot {
    * Refresh tocbot if the document changes and it needs to be rebuilt.
    * @see https://github.com/tscanlin/tocbot#refresh
    */
-  function refresh(): void;
+  function refresh(options?: IStaticOptions): void;
 }


### PR DESCRIPTION
Hey again, ran into a blocking problem where using `refresh` with custom options in TypeScript throws an error because the `index.d.ts` file doesn't have the options in the signature. Since the file isn't generated, I'm opening this PR to manually correct it.

@tscanlin, if you approve, feel free to merge and publish it yourself 👍🏻 