### PR TITLE
Prevent hidden nodes showing up in the table of contents by replacing `textContent` with `innerText`

### DIFF
--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -82,7 +82,7 @@ module.exports = function (options) {
     }
 
     if (options.includeTitleTags) {
-      a.setAttribute('title', data.textContent)
+      a.setAttribute('title', data.innerText)
     }
 
     if (options.includeHtml && data.childNodes.length) {
@@ -91,7 +91,7 @@ module.exports = function (options) {
       })
     } else {
       // Default behavior.
-      a.textContent = data.textContent
+      a.innerText = data.innerText
     }
     a.setAttribute('href', options.basePath + '#' + data.id)
     a.setAttribute('class', options.linkClass +

--- a/src/js/parse-content.js
+++ b/src/js/parse-content.js
@@ -60,7 +60,7 @@ module.exports = function parseContent (options) {
     }
 
     const headingLabel = heading.getAttribute('data-heading-label') ||
-      (options.headingLabelCallback ? String(options.headingLabelCallback(heading.textContent)) : heading.textContent.trim())
+      (options.headingLabelCallback ? String(options.headingLabelCallback(heading.innerText)) : heading.innerText.trim())
     var obj = {
       id: heading.id,
       children: [],

--- a/src/utils/make-ids.js
+++ b/src/utils/make-ids.js
@@ -8,7 +8,7 @@ function makeIds () { // eslint-disable-line
   Array.prototype.forEach.call(headings, function (heading) {
     var id = heading.id
       ? heading.id
-      : heading.textContent.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+      : heading.innerText.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
     headingMap[id] = !isNaN(headingMap[id]) ? ++headingMap[id] : 0
     if (headingMap[id]) {
       heading.id = id + '-' + headingMap[id]

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ before(function (done) {
   GLOBAL.window = window
   window.document.body.innerHTML = content
   const scriptEl = window.document.createElement("script")
-  scriptEl.textContent = jsContent
+  scriptEl.innerText = jsContent
   window.document.body.appendChild(scriptEl)
   tocbot = window.tocbot
   
@@ -117,7 +117,7 @@ describe('Parse content', function () {
     var contentEl = GLOBAL.window.document.querySelector(tocbot.options.contentSelector)
     var defaultHeadings = selectHeadings(contentEl, tocbot.options.headingSelector)
     defaultHeadings = [].map.call(defaultHeadings, function (node) {
-      return node.textContent
+      return node.innerText
     })
 
     expect(defaultHeadings).to.eql([
@@ -148,7 +148,7 @@ describe('Parse content', function () {
     var contentEl = GLOBAL.window.document.querySelector(tocbot.options.contentSelector)
     var defaultHeadings = selectHeadings(contentEl, 'h1, h2')
     defaultHeadings = [].map.call(defaultHeadings, function (node) {
-      return node.textContent
+      return node.innerText
     })
 
     expect(defaultHeadings).to.eql([
@@ -200,7 +200,7 @@ describe('Build HTML', function () {
       GLOBAL.window.document.createTextNode('What'),
       GLOBAL.window.document.createElement('SUP')
     ]
-    nodes[1].textContent = 'sup'
+    nodes[1].innerText = 'sup'
     var tocEl = GLOBAL.window.document.querySelector(tocbot.options.tocSelector)
     var tocEl = render(tocEl, [{
       'id': 'Whatsup',
@@ -225,7 +225,7 @@ describe('Build HTML', function () {
       GLOBAL.window.document.createTextNode('What'),
       GLOBAL.window.document.createElement('SUP')
     ]
-    nodes[1].textContent = 'sup'
+    nodes[1].innerText = 'sup'
     var tocEl = GLOBAL.window.document.querySelector(tocbot.options.tocSelector)
     var tocEl = render(tocEl, [{
       'id': 'Whatsup',


### PR DESCRIPTION
This change should prevent hidden child nodes inside headings, like <style> elements or labels for assistive technology, to appear in the table of contents.

<img width="528" alt="image" src="https://github.com/tscanlin/tocbot/assets/15028273/8edff7b2-226f-492b-8d41-0703fd695dae">


Here's a Stackblitz to reproduce the issue: https://stackblitz.com/edit/web-platform-hdw8zg?file=index.html

Simple test setup:

```html
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.18.2/tocbot.css">

<main id="content">
  <h2 id="foo">
    <style>
      span {
        color: red;
      }
    </style>
    Hello <span>World!</span>
  </h2>
</main>

<nav id="toc"></nav>

<script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.18.2/tocbot.min.js"></script>
<script>
  tocbot.init({
    tocSelector: '#toc',
    contentSelector: '#content',
    headingSelector: 'h1, h2, h3'
  });
</script>
```

Note: I did not really test if all the changes I did work as expected (shame on me) but replaced all `textContent` with `innerText`. Anyone with more knowledge of the Tocbot codebase might have some more insights.

Alternatively this could also be an additional configuration option like `ignoreHiddenChildNodes: boolean` in order to prevent any breaking changes...

I would be happy if we can resolve this issue.

Thanks in advance.