### PR TITLE
CDN download URL: bump outdated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OR
 Include the script at the bottom of the page before the closing body tag.
 
 ```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.18.2/tocbot.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.25.0/tocbot.min.js"></script>
 ```
 
 
@@ -38,7 +38,7 @@ Include the script at the bottom of the page before the closing body tag.
 CSS is used for expanding & collapsing groupings and some basic styling.
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.18.2/tocbot.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.25.0/tocbot.css">
 ```
 
 OR
@@ -92,7 +92,6 @@ tocbot.destroy();
 ## Examples
 
 - [Tocbot Homepage](https://tscanlin.github.io/tocbot/)
-- [Pagekit TOC](https://spqr.wtf/projects/toc)
 - [Optimizely's Developer Documentation](https://developers.optimizely.com/x/solutions/javascript/reference/index.html)
 
 If you'd like to add your page to this list open a pull request.

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -111,7 +111,7 @@ module.exports = function (options) {
     var list = document.createElement(listElement)
     var classes = options.listClass + SPACE_CHAR + options.extraListClasses
     if (isCollapsed) {
-      // No plus/equals here fixes compilcation issue.
+      // No plus/equals here fixes compilation issue.
       classes = classes + SPACE_CHAR + options.collapsibleClass
       classes = classes + SPACE_CHAR + options.isCollapsedClass
     }


### PR DESCRIPTION
This PR corrects the CDN download URLs by bumping the outdated versions given there.
It also removes a example site that does not exist any more and fixes a typo.