### PR TITLE
switch to getByElementId to fix encoding edge case

### DIFF
--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -339,7 +339,7 @@ export default function (options) {
 
   function getIsHeaderBottomMode(headerId) {
     const scrollEl = getScrollEl()
-    const activeHeading = scrollEl?.getElementById(headerId)
+    const activeHeading = document?.getElementById(headerId)
     const isBottomMode =
       activeHeading.offsetTop >
       scrollEl.offsetHeight -

--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -339,7 +339,7 @@ export default function (options) {
 
   function getIsHeaderBottomMode(headerId) {
     const scrollEl = getScrollEl()
-    const activeHeading = scrollEl?.querySelector(`#${headerId}`)
+    const activeHeading = scrollEl?.getElementById(headerId)
     const isBottomMode =
       activeHeading.offsetTop >
       scrollEl.offsetHeight -


### PR DESCRIPTION
switch to getByElementId to fix encoding edge case for #377 