### PR TITLE
add css to make tocbot more a11y friendly

### DIFF
--- a/src/scss/_tocbot-core.scss
+++ b/src/scss/_tocbot-core.scss
@@ -34,6 +34,10 @@ a.toc-link {
 
 .is-collapsed {
   max-height: 0;
+
+  &:has(:focus) {
+    max-height: 1000px;
+  }
 }
 
 .is-position-fixed {


### PR DESCRIPTION
Fix for #387 

Improve a11y by making focused section expand.

<img width="310" alt="Screenshot 2025-05-27 at 9 01 47 PM" src="https://github.com/user-attachments/assets/f6e1c2dd-4136-4b11-a67b-9201ce431642" />
