### PR TITLE
Fix error when the url hash doesn't match an existing heading

### DIFF
--- a/src/js/build-html.js
+++ b/src/js/build-html.js
@@ -351,7 +351,7 @@ export default function (options) {
     const scrollEl = getScrollEl()
     const activeHeading = document?.getElementById(headerId)
     const isBottomMode =
-      activeHeading.offsetTop >
+      activeHeading && activeHeading.offsetTop >
       scrollEl.offsetHeight -
         scrollEl.clientHeight * 1.4 -
         options.bottomModeThreshold


### PR DESCRIPTION
This fixes an **Uncaught TypeError** that happens when the URL has a hash that doesn't match a heading ID. 
In my case, the hash is used by the CMS for other purposes.